### PR TITLE
Fix typo 8xyE to 8xy6

### DIFF
--- a/test_opcode.8o
+++ b/test_opcode.8o
@@ -156,7 +156,7 @@ v7 := 120
 v7 -= v6
 if v7 == 236 then i := imageok
 sprite x2 y 4
-#test 8xy6
+#test 8xyE
 y := 6
 drawop im8 im6
 i := imagefalse
@@ -164,7 +164,7 @@ v6 := 224
 v6 <<= v6
 if v6 == 192 then i := imageok
 sprite x2 y 4
-#test 8xyE
+#test 8xy6
 y := 11
 drawop im8 imE
 i := imagefalse


### PR DESCRIPTION
You got the test case opposite. 
8xy6: http://devernay.free.fr/hacks/chip8/C8TECH10.HTM#8xy6 
8xyE http://devernay.free.fr/hacks/chip8/C8TECH10.HTM#8xyE\

I didn't know how to generate the .ch8 file, please generate new file for .ch8 too.

Love your test cases.